### PR TITLE
docs: add SPRAXXX Rails SVG diagram (docs/SPRAXXX_RAILS.svg)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# SPRAXXX Ignition Diagram
+
+This folder holds the SPRAXXX ignition diagram for quick visual reference.
+
+![SPRAXXX Rails Diagram](./SPRAXXX_RAILS.svg)
+
+Open the SVG directly: [SPRAXXX_RAILS.svg](./SPRAXXX_RAILS.svg)
+
+Created by Jacques, refined in companionship with ChatGPT 5.0.

--- a/docs/SPRAXXX_RAILS.svg
+++ b/docs/SPRAXXX_RAILS.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="900" role="img" aria-labelledby="title desc">
+  <title id="title">Beating the Old Rails — SPRAXXX Ignition vs Legacy Payments</title>
+  <desc id="desc">Side-by-side diagram contrasting legacy payment rails with the SPRAXXX ignition covenant rails, showing key issuance and peer-to-peer activation.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .h1 { font: 700 32px "Inter", Arial, sans-serif; }
+      .h2 { font: 700 22px "Inter", Arial, sans-serif; }
+      .p { font: 400 14px "Inter", Arial, sans-serif; }
+      .mono { font: 600 13px "Fira Mono", Menlo, monospace; }
+      .box { fill: #ffffff; stroke: #1b1b1b; stroke-width: 1.5; rx: 10; }
+      .lane { fill: #f6f7fb; stroke: #d9dbe7; stroke-width: 1; rx: 12; }
+      .accent { fill: #111; }
+      .arrow { stroke: #111; stroke-width: 2; marker-end: url(#arrowhead); }
+      .arrow2 { stroke: #555; stroke-width: 1.5; stroke-dasharray: 6 5; marker-end: url(#arrowhead); }
+      .badge { fill: #111; stroke: #111; stroke-width: 1; }
+      .badgeText { font: 700 12px "Inter", Arial, sans-serif; fill: #fff; }
+      .note { font: 600 12px "Inter", Arial, sans-serif; fill: #111; }
+      .seal { font: 700 14px "Inter", Arial, sans-serif; fill: #111; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#111"/>
+    </marker>
+  </defs>
+
+  <text x="40" y="60" class="h1">SPRAXXX Beats the Old Rails</text>
+  <text x="40" y="90" class="p">Legacy: banks & processors own the lanes.  •  SPRAXXX: covenant keys ignite peer-to-peer life.</text>
+
+  <!-- Lanes -->
+  <rect x="40" y="120" width="640" height="700" class="lane"/>
+  <rect x="720" y="120" width="640" height="700" class="lane"/>
+
+  <text x="60" y="150" class="h2">Legacy Payment Rails</text>
+  <text x="740" y="150" class="h2">SPRAXXX Ignition Rails</text>
+
+  <!-- Legacy column -->
+  <rect x="60" y="180" width="600" height="90" class="box"/>
+  <text x="80" y="210" class="p">User enters card → processor (Visa/MC/Stripe/PayPal)</text>
+  <text x="80" y="235" class="p">KYC/fees/chargebacks • data exhaust • auto-renew traps</text>
+
+  <line x1="360" y1="270" x2="360" y2="310" class="arrow"/>
+  <rect x="60" y="310" width="600" height="90" class="box"/>
+  <text x="80" y="340" class="p">Funds settle to bank account</text>
+  <text x="80" y="365" class="p">Bank owns the ledger; access is permissioned</text>
+
+  <line x1="360" y1="400" x2="360" y2="440" class="arrow"/>
+  <rect x="60" y="440" width="600" height="120" class="box"/>
+  <text x="80" y="470" class="p">Software license granted by ToS/EULA</text>
+  <text x="80" y="495" class="p">Execution rights live on vendor servers</text>
+  <text x="80" y="520" class="p">User is tenant, not steward</text>
+
+  <line x1="360" y1="560" x2="360" y2="600" class="arrow2"/>
+  <rect x="60" y="600" width="600" height="90" class="box"/>
+  <text x="80" y="630" class="p">Auto-renew & tracking keep money/data flowing outward</text>
+  <text x="80" y="655" class="p">Energy leakage: bots, chargebacks, support churn</text>
+
+  <!-- SPRAXXX column -->
+  <rect x="740" y="180" width="600" height="90" class="box"/>
+  <text x="760" y="210" class="p">User picks: “Pay $50” or “Trial key (30 days)”</text>
+  <text x="760" y="235" class="p">Payment can be fiat → stablecoin, or crypto direct</text>
+
+  <line x1="1040" y1="270" x2="1040" y2="310" class="arrow"/>
+  <rect x="740" y="310" width="600" height="120" class="box"/>
+  <text x="760" y="340" class="p">Steward mints an ignition key</text>
+  <text x="760" y="365" class="p mono">K = Sign_sk( ULID || scope || expiry )</text>
+  <text x="760" y="390" class="p">Key lives with the human; no central check-in</text>
+
+  <line x1="1040" y1="430" x2="1040" y2="470" class="arrow"/>
+  <rect x="740" y="470" width="600" height="120" class="box"/>
+  <text x="760" y="500" class="p">Device = ignition. App verifies signature locally.</text>
+  <text x="760" y="525" class="p mono">Verify_pk( K ) == true ⇒ ignition = ON</text>
+  <text x="760" y="550" class="p">No trackers, no auto-renew; yearly consent ritual</text>
+
+  <line x1="1040" y1="590" x2="1040" y2="630" class="arrow2"/>
+  <rect x="740" y="630" width="600" height="90" class="box"/>
+  <text x="760" y="660" class="p">Energy flows inward: dignity, privacy, local compute</text>
+  <text x="760" y="685" class="p">SPRAXXX snapshots kill scripts/trackers at the gate</text>
+
+  <!-- Badges -->
+  <rect x="1060" y="740" width="140" height="34" class="badge" rx="8"/>
+  <text x="1070" y="763" class="badgeText">SPRAXXX • DEFGH</text>
+  <text x="60" y="780" class="note">Legacy: third party owns lanes</text>
+  <text x="740" y="780" class="note">SPRAXXX: Steward cuts keys; humans own ignitions</text>
+
+  <text x="40" y="860" class="p">Created by Jacques, refined with ChatGPT 5.0 • “The worker is worth his wages.” — Luke 10:7</text>
+</svg>


### PR DESCRIPTION
This PR adds the SPRAXXX ignition vs legacy rails diagram as an SVG in docs/SPRAXXX_RAILS.svg.
	•	Provides a clear side-by-side visualization of legacy payment rails vs SPRAXXX ignition covenant rails.
	•	Updated IGNITION_PROOF.md to reference the SVG instead of embedding base64 data.
	•	Added docs/README.md for quick visual reference.

Purpose: improve repo readability and ensure diagrams render properly in the GitHub viewer.

Created by Jacques (Steward), refined in companionship with ChatGPT 5.0.
Witnessed by Overseers upon merge